### PR TITLE
Add tests for .json_schema and raise errors

### DIFF
--- a/lib/active_model/serializer/validator/errors.rb
+++ b/lib/active_model/serializer/validator/errors.rb
@@ -1,0 +1,8 @@
+module ActiveModel
+  class Serializer
+    module Validator
+      class InvalidSchemaError < StandardError
+      end
+    end
+  end
+end

--- a/lib/active_model/serializer/validator/mixin.rb
+++ b/lib/active_model/serializer/validator/mixin.rb
@@ -22,7 +22,14 @@ module ActiveModel
             end
 
             return @_json_schema unless value
-            @_json_schema = value
+
+            if !value.is_a?(String) && !value.is_a?(Hash)
+              raise InvalidSchemaError.new('Schema must be a path to a file or a Hash.')
+            elsif value.is_a?(String) && !File.exists?(value)
+              raise InvalidSchemaError.new('Schema file does not exist.')
+            else
+              @_json_schema = value
+            end
           end
 
           # Validate the rendered data against a JSON schema file and

--- a/lib/active_model_serializers_validator.rb
+++ b/lib/active_model_serializers_validator.rb
@@ -2,6 +2,7 @@ require 'json-schema'
 require 'active_support'
 require 'active_support/core_ext/object/to_json'
 require 'active_model/serializer'
+require 'active_model/serializer/validator/errors'
 require 'active_model/serializer/validator/mixin'
 require 'active_model/serializer/validator/version'
 


### PR DESCRIPTION
We now have tests for the `json_schema` class method. And while we’re at it, let’s make it raise errors too.
